### PR TITLE
Fixed import of okhttp after upgrade to React Native 0.27

### DIFF
--- a/android/src/main/java/com/aerofs/reactnativeautoupdater/ReactNativeAutoUpdater.java
+++ b/android/src/main/java/com/aerofs/reactnativeautoupdater/ReactNativeAutoUpdater.java
@@ -264,7 +264,7 @@ public class ReactNativeAutoUpdater {
     }
 
     private void showProgressToast(int message) {
-        if (this.showProgress) {
+        if (this.showProgress && context.getResources().getString(message).length() > 0) {
             int duration = Toast.LENGTH_SHORT;
             Toast toast = Toast.makeText(context, message, duration);
             toast.show();

--- a/android/src/main/java/com/aerofs/reactnativeautoupdater/ReactNativeAutoUpdater.java
+++ b/android/src/main/java/com/aerofs/reactnativeautoupdater/ReactNativeAutoUpdater.java
@@ -7,9 +7,9 @@ import android.os.AsyncTask;
 import android.os.PowerManager;
 import android.widget.Toast;
 
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.Response;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 
 import org.json.JSONObject;
 


### PR DESCRIPTION
Had an error after upgrading to React Native 0.27 because of this:
https://github.com/facebook/react-native/commit/6bbaff2944dafd6fa7e5b77ef46dece0ec2c9983

And added check for displaying Toast at Android only if string length is greater than 0.
